### PR TITLE
[Refactor] 기존 utility 스타일로만 명시된 타이포그래피 스타일을 컴포넌트화하여 추가

### DIFF
--- a/src/components/ui/common/Typography.tsx
+++ b/src/components/ui/common/Typography.tsx
@@ -1,0 +1,67 @@
+import { cn } from '@/lib/utils';
+import type { TitleProps, SubTitleProps, BodyProps, CaptionProps, TypographyType } from '@/types/TypographyTypes';
+
+export function Title({ level = 2, children, className = '' }: TitleProps) {
+  return (
+    <h2
+      className={cn(
+        `${level === 1 ? '!text-title1' : ''}`,
+        `${level === 2 ? '!text-title2' : ''}`,
+        `${level === 3 ? '!text-title3' : ''}`,
+        className,
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function SubTitle({ level = 2, children, className = '' }: SubTitleProps) {
+  return (
+    <h3
+      className={cn(
+        `${level === 1 ? '!text-subtitle1' : ''}`,
+        `${level === 2 ? '!text-subtitle2' : ''}`,
+        `${level === 3 ? '!text-subtitle3' : ''}`,
+        className,
+      )}
+    >
+      {children}
+    </h3>
+  );
+}
+
+export function Body({ level = 2, children, className = '' }: BodyProps) {
+  return (
+    <p
+      className={cn(
+        `${level === 1 ? '!text-body1' : ''}`,
+        `${level === 2 ? '!text-body2' : ''}`,
+        `${level === 3 ? '!text-body3' : ''}`,
+        `${level === 4 ? '!text-body4' : ''}`,
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+export function Caption({ level = 2, children, className = '' }: CaptionProps) {
+  return (
+    <p
+      className={cn(
+        `${level === 1 ? '!text-caption1' : ''}`,
+        `${level === 2 ? '!text-caption2' : ''}`,
+        `${level === 3 ? '!text-caption3' : ''}`,
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+export function Extra({ children, className = '' }: TypographyType) {
+  return <p className={cn('!text-extra', className)}>{children}</p>;
+}

--- a/src/components/ui/common/index.ts
+++ b/src/components/ui/common/index.ts
@@ -5,3 +5,4 @@ export { RadioGroup, RadioGroupItem } from './radio-group';
 export { BottomSheet } from './BottomSheet';
 export { Tag } from './Tag';
 export { ActionList } from './ActionList';
+export { Title, SubTitle, Body, Caption, Extra } from './Typography';

--- a/src/types/TypographyTypes.ts
+++ b/src/types/TypographyTypes.ts
@@ -1,0 +1,20 @@
+export type TypographyType = {
+  className?: string;
+  children?: Readonly<React.ReactNode>;
+};
+
+export interface TitleProps extends TypographyType {
+  level?: 1 | 2 | 3;
+}
+
+export interface SubTitleProps extends TypographyType {
+  level?: 1 | 2 | 3;
+}
+
+export interface BodyProps extends TypographyType {
+  level?: 1 | 2 | 3 | 4;
+}
+
+export interface CaptionProps extends TypographyType {
+  level?: 1 | 2 | 3;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
#27 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기존 utility 스타일로만 명시된 타이포그래피 스타일을 컴포넌트화하여 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- title, subtitle, body, caption, extra만 컴포넌트 추가 button은 기존 Button.tsx에 추가되어 있어 따로 추가하지 않았습니다.