### PR TITLE
[Feat] 상품 조회 페이지 상품 리스트 섹션 퍼블리싱

### DIFF
--- a/src/actions/product-service/index.ts
+++ b/src/actions/product-service/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@/types/products/productCategoryType';
 import { ProductOptionType } from '@/types/products/productPurchaseTypes';
 import { ProductTagsType } from '@/types/products/productRequestTypes';
-import { ProductListData, ProductsWithDetailsData, ProductTypes } from '@/types/products/productTypes';
+import { ProductListDataType, ProductsWithDetailsDataType, ProductTypes } from '@/types/products/productTypes';
 
 export const getProductDetail = async (productCode: number): Promise<ProductTypes> => {
   try {
@@ -179,7 +179,7 @@ export async function getSubCategoriesAndVolume(topCategoryId: number): Promise<
   }
 }
 
-export async function getFilteredProducts(params: SearchParamsType): Promise<ProductListData> {
+export async function getFilteredProducts(params: SearchParamsType): Promise<ProductListDataType> {
   const queryParams = new URLSearchParams();
 
   if (params.cursor) queryParams.append('cursor', params.cursor);
@@ -211,7 +211,7 @@ export async function getFilteredProducts(params: SearchParamsType): Promise<Pro
   }
 }
 
-export async function getFilteredProductsWithDetails(params: SearchParamsType): Promise<ProductsWithDetailsData> {
+export async function getFilteredProductsWithDetails(params: SearchParamsType): Promise<ProductsWithDetailsDataType> {
   // 필터링된 상품 목록 가져오기 (이제 직접 data 객체를 반환)
   const productListData = await getFilteredProducts(params);
 
@@ -247,7 +247,7 @@ export const getProductDetailDummy = async (productCode: number) => {
   }
 };
 
-export async function fetchMoreProducts(params: SearchParamsType): Promise<ProductListData> {
+export async function fetchMoreProducts(params: SearchParamsType): Promise<ProductListDataType> {
   try {
     const queryParams = new URLSearchParams();
 

--- a/src/actions/product-service/index.ts
+++ b/src/actions/product-service/index.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
 import {
   FilterDataType,
   ProductCategoryTopType,
@@ -8,9 +9,9 @@ import {
 } from '@/types/products/productCategoryType';
 import { ProductOptionType } from '@/types/products/productPurchaseTypes';
 import { ProductTagsType } from '@/types/products/productRequestTypes';
-import { ProductTypes } from '@/types/products/productTypes';
+import { ProductListData, ProductsWithDetailsData, ProductTypes } from '@/types/products/productTypes';
 
-export const getProductDetail = async (productCode: string): Promise<ProductTypes> => {
+export const getProductDetail = async (productCode: number): Promise<ProductTypes> => {
   try {
     const response = await fetch(`http://localhost:8080/api/v1/products/${productCode}`);
     if (!response.ok) {
@@ -25,7 +26,7 @@ export const getProductDetail = async (productCode: string): Promise<ProductType
   }
 };
 
-export const getProductTags = async (productCode: string): Promise<ProductTagsType> => {
+export const getProductTags = async (productCode: number): Promise<ProductTagsType> => {
   try {
     const response = await fetch(`http://localhost:8080/api/v1/products/${productCode}/tags`);
     if (!response.ok) {
@@ -40,7 +41,7 @@ export const getProductTags = async (productCode: string): Promise<ProductTagsTy
   }
 };
 
-export const getProductOptions = async (productCode: string): Promise<ProductOptionType[]> => {
+export const getProductOptions = async (productCode: number): Promise<ProductOptionType[]> => {
   try {
     const response = await fetch(`http://localhost:8080/api/v1/products/${productCode}/options`);
     if (!response.ok) {
@@ -75,7 +76,7 @@ export const getProductOptions = async (productCode: string): Promise<ProductOpt
   }
 };
 
-export async function getProductCategories(topCategoryId: string): Promise<ProductCategoryTopType[]> {
+export async function getProductCategories(topCategoryId: number): Promise<ProductCategoryTopType[]> {
   try {
     const response = await fetch(`http://localhost:8080/api/v1/categories/${topCategoryId}/subcategories`);
     if (!response.ok) {
@@ -91,7 +92,7 @@ export async function getProductCategories(topCategoryId: string): Promise<Produ
 }
 
 // 카테고리 ID에 따른 필터 옵션 조회
-export async function getProductFilters(topCategoryId: string): Promise<FilterDataType> {
+export async function getProductFilters(topCategoryId: number): Promise<FilterDataType> {
   try {
     const response = await fetch(`http://localhost:8080/api/v1/categories/${topCategoryId}/filters`);
     if (!response.ok) {
@@ -114,14 +115,14 @@ type SubCategoriesAndVolume = {
   subDetailCategories: SubDetailCategoryType[];
   subVolumeCategories: SubSizeCateogryType[];
 };
-export async function getSubCategoriesAndVolume(topCategoryId: string): Promise<SubCategoriesAndVolume> {
+export async function getSubCategoriesAndVolume(topCategoryId: number): Promise<SubCategoriesAndVolume> {
   switch (topCategoryId) {
-    case '1': // 전체
+    case 1: // 전체
       return {
         subDetailCategories: [],
         subVolumeCategories: [],
       };
-    case '2': // 텀블러/보온병
+    case 2: // 텀블러/보온병
       return {
         subDetailCategories: [
           { bottomCategoryId: 1, categoryName: '플라스틱 텀블러' },
@@ -135,7 +136,7 @@ export async function getSubCategoriesAndVolume(topCategoryId: string): Promise<
           { sizeId: 'venti', sizeName: 'Venti' },
         ],
       };
-    case '3': // 머그/컵
+    case 3: // 머그/컵
       return {
         subDetailCategories: [
           { bottomCategoryId: 1, categoryName: '스테인리스 머그' },
@@ -148,7 +149,7 @@ export async function getSubCategoriesAndVolume(topCategoryId: string): Promise<
           { sizeId: 'grande', sizeName: 'Grande' },
         ],
       };
-    case '4': // 라이프스타일
+    case 4: // 라이프스타일
       return {
         subDetailCategories: [
           { bottomCategoryId: 1, categoryName: '키친' },
@@ -157,7 +158,7 @@ export async function getSubCategoriesAndVolume(topCategoryId: string): Promise<
         ],
         subVolumeCategories: [],
       };
-    case '5': // 티/커피
+    case 5: // 티/커피
       return {
         subDetailCategories: [
           { bottomCategoryId: 1, categoryName: '티 용품' },
@@ -175,5 +176,106 @@ export async function getSubCategoriesAndVolume(topCategoryId: string): Promise<
         subDetailCategories: [],
         subVolumeCategories: [],
       };
+  }
+}
+
+export async function getFilteredProducts(params: SearchParamsType): Promise<ProductListData> {
+  const queryParams = new URLSearchParams();
+
+  if (params.cursor) queryParams.append('cursor', params.cursor);
+  if (params.minPrice) queryParams.append('minPrice', params.minPrice);
+  if (params.maxPrice) queryParams.append('maxPrice', params.maxPrice);
+  if (params.topCategoryId) queryParams.append('topCategoryId', params.topCategoryId);
+
+  if (params.bottomCategoryIds) {
+    const bottomCategoryIdsStr = Array.isArray(params.bottomCategoryIds)
+      ? params.bottomCategoryIds.join(',')
+      : params.bottomCategoryIds;
+    queryParams.append('bottomCategoryIds', bottomCategoryIdsStr);
+  }
+
+  if (params.size) queryParams.append('size', params.size);
+  if (params.sortBy) queryParams.append('sortBy', params.sortBy);
+
+  try {
+    const response = await fetch(`http://localhost:8080/api/product-category-list?${queryParams.toString()}`);
+    if (!response.ok) {
+      throw new Error('상품 목록을 가져오는데 실패했습니다.');
+    }
+
+    const data = await response.json();
+    return data.data;
+  } catch (error) {
+    console.error('상품 데이터 패칭 오류:', error);
+    throw error;
+  }
+}
+
+export async function getFilteredProductsWithDetails(params: SearchParamsType): Promise<ProductsWithDetailsData> {
+  // 필터링된 상품 목록 가져오기 (이제 직접 data 객체를 반환)
+  const productListData = await getFilteredProducts(params);
+
+  if (!productListData.content.length) {
+    return {
+      ...productListData,
+      productDetails: [],
+    };
+  }
+
+  // 각 상품의 상세 정보를 병렬로 가져오기
+  const productDetails = await Promise.all(productListData.content.map((item) => getProductDetail(item.productCode)));
+
+  // 상품 목록 데이터와 상세 정보를 합쳐서 반환
+  return {
+    ...productListData,
+    productDetails,
+  };
+}
+
+export const getProductDetailDummy = async (productCode: number) => {
+  try {
+    // 고정된 더미 데이터 반환
+    return {
+      productCode: productCode,
+      productName: 'SS 플라워 마켓 스탠리 텀블러 591ml',
+      price: 43000,
+      productThumbnailUrl: '/images/products/tumbler1.jpg',
+    };
+  } catch (error) {
+    console.error('더미 상품 정보 생성 중 오류 발생:', error);
+    throw error;
+  }
+};
+
+export async function fetchMoreProducts(params: SearchParamsType): Promise<ProductListData> {
+  try {
+    const queryParams = new URLSearchParams();
+
+    if (params.cursor) queryParams.append('cursor', params.cursor);
+    if (params.minPrice) queryParams.append('minPrice', params.minPrice);
+    if (params.maxPrice) queryParams.append('maxPrice', params.maxPrice);
+    if (params.topCategoryId) queryParams.append('topCategoryId', params.topCategoryId);
+
+    if (params.bottomCategoryIds) {
+      const bottomCategoryIdsStr = Array.isArray(params.bottomCategoryIds)
+        ? params.bottomCategoryIds.join(',')
+        : params.bottomCategoryIds;
+      queryParams.append('bottomCategoryIds', bottomCategoryIdsStr);
+    }
+
+    if (params.size) queryParams.append('size', params.size);
+    if (params.sortBy) queryParams.append('sortBy', params.sortBy);
+
+    const response = await fetch(`/product-category-list?${queryParams.toString()}`);
+
+    if (!response.ok) {
+      throw new Error('추가 상품을 불러오는데 실패했습니다.');
+    }
+
+    const result = await response.json();
+    return result.data; // 백엔드 응답에서 data 부분만 사용
+  } catch (error) {
+    console.error('추가 상품 로드 오류:', error);
+    throw error;
   }
 }

--- a/src/actions/product-service/index.ts
+++ b/src/actions/product-service/index.ts
@@ -229,6 +229,7 @@ export const getProductDetailDummy = async (productCode: number) => {
       productName: 'SS 플라워 마켓 스탠리 텀블러 591ml',
       price: 43000,
       productThumbnailUrl: '/images/productThumbnails/1000.png',
+      isBest: true,
     };
   } catch (error) {
     console.error('더미 상품 정보 생성 중 오류 발생:', error);

--- a/src/app/(main)/(products)/products/page.tsx
+++ b/src/app/(main)/(products)/products/page.tsx
@@ -5,7 +5,12 @@ import ProductCategoryTopTabBar from '@/components/layouts/product/ProductCatego
 import ProductDetailCategorySection from '@/components/layouts/product/ProductDetailCategorySection';
 // import { getProductCategories, getProductFilters } from '@/actions/product-service';
 import { sampleFilterData } from '@/data/productDummy/productCategoryTopDummyDatas';
-import { getSubCategoriesAndVolume } from '@/actions/product-service';
+import {
+  // getFilteredProductsWithDetails,
+  getSubCategoriesAndVolume,
+} from '@/actions/product-service';
+import FilteredProductSection from '@/components/layouts/product/FilteredProductSection';
+import { getInitialProductsData } from '@/data/productDummy/filteredProductDummy';
 
 type SearchParams = Promise<SearchParamsType>;
 
@@ -19,6 +24,8 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
     filteredParams[key] = value;
   });
 
+  filteredParams.size = filteredParams.size || '10';
+
   // FIXME: 서버에서 데이터 가져오기 현재는 더미로 할 예정
   // const [subCategories, filterOptions] = await Promise.all([
   //   getProductCategories(topCategoryId),
@@ -26,8 +33,14 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
   // ]);
 
   // FIXME: 더미로 우선은 할 예정
-  const { subDetailCategories, subVolumeCategories } = await getSubCategoriesAndVolume(topCategoryId);
+  const { subDetailCategories, subVolumeCategories } = await getSubCategoriesAndVolume(Number(topCategoryId));
 
+  // FIXME: API호출 우선 구현은 되었고, 더미로 진행 예정
+  //const productsWithDeatilsData = await getFilteredProductsWithDetails(filteredParams);
+
+  const initialProductsData = getInitialProductsData();
+
+  // 초기 상품들 랜더링
   return (
     <main>
       <ProductCategoryTopTabBar initialCategory={topCategoryId} />
@@ -38,7 +51,7 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
         filterOptions={sampleFilterData}
       />
       {/* TODO: 상품 리스트 영역 */}
-      {/* <ProductList data={productListData} /> */}
+      <FilteredProductSection searchParams={filteredParams} initialProductsData={initialProductsData} />
     </main>
   );
 }

--- a/src/app/(main)/(products)/products/page.tsx
+++ b/src/app/(main)/(products)/products/page.tsx
@@ -10,7 +10,7 @@ import {
   getSubCategoriesAndVolume,
 } from '@/actions/product-service';
 import FilteredProductSection from '@/components/layouts/product/FilteredProductSection';
-import { getInitialProductsData } from '@/data/productDummy/filteredProductDummy';
+import { getInitialProductsDummyData } from '@/data/productDummy/filteredProductDummy';
 
 type SearchParams = Promise<SearchParamsType>;
 
@@ -36,9 +36,9 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
   const { subDetailCategories, subVolumeCategories } = await getSubCategoriesAndVolume(Number(topCategoryId));
 
   // FIXME: API호출 우선 구현은 되었고, 더미로 진행 예정
-  //const productsWithDeatilsData = await getFilteredProductsWithDetails(filteredParams);
+  // const initialProductsData = getInitialProductsData();
 
-  const initialProductsData = getInitialProductsData();
+  const initialProductsData = getInitialProductsDummyData();
 
   // 초기 상품들 랜더링
   return (

--- a/src/app/(main)/(products)/products/page.tsx
+++ b/src/app/(main)/(products)/products/page.tsx
@@ -21,10 +21,11 @@ export default async function ProductsPage(props: { searchParams: SearchParams }
   // 필터링된 파라미터 객체 생성
   const filteredParams: SearchParamsType = {};
   Object.entries(searchParams).forEach(([key, value]) => {
+    if (key === 'size') {
+      return (filteredParams[key] = value ? (value as string) : '10');
+    }
     filteredParams[key] = value;
   });
-
-  filteredParams.size = filteredParams.size || '10';
 
   // FIXME: 서버에서 데이터 가져오기 현재는 더미로 할 예정
   // const [subCategories, filterOptions] = await Promise.all([

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useState, useRef, useCallback } from 'react';
+import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
+import FilteredProductItemCard from '@/components/modules/product/FilteredProductItemCard';
+import { getInitialProductsData } from '@/data/productDummy/filteredProductDummy';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+interface ProductItem {
+  id: number;
+  productCode: number;
+}
+
+interface ProductListData {
+  content: ProductItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+}
+
+interface FilteredProductSectionProps {
+  searchParams: SearchParamsType;
+  initialProductsData: ProductListData;
+}
+
+async function fetchMoreProductsDummy(params: SearchParamsType): Promise<ProductListData> {
+  try {
+    // 지연 효과를 주기 위한 setTimeout 사용
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const cursor = params.cursor ? Number(params.cursor) : undefined;
+        const moreData = getInitialProductsData(cursor);
+        resolve(moreData);
+      }, 300); // 로딩 효과를 보여주기 위한 지연
+    });
+  } catch (error) {
+    console.error('추가 상품 로드 오류:', error);
+    throw error;
+  }
+}
+
+export default function FilteredProductSection({ searchParams, initialProductsData }: FilteredProductSectionProps) {
+  const router = useRouter();
+  const searchParamsObj = useSearchParams();
+
+  const cursor = searchParamsObj.get('cursor') ? Number(searchParamsObj.get('cursor')) : initialProductsData.nextCursor;
+
+  const [productsData, setProductsData] = useState<ProductListData>(initialProductsData);
+  const [loading, setLoading] = useState(false);
+
+  const [hasMore, setHasMore] = useState(initialProductsData.hasNext);
+
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const lastProductRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (loading) return;
+
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          loadMoreProducts();
+        }
+      });
+
+      if (node) observerRef.current.observe(node);
+    },
+    [loading, hasMore, cursor],
+  );
+
+  const loadMoreProducts = async () => {
+    if (!hasMore || loading) return;
+
+    setLoading(true);
+
+    try {
+      const nextParams: SearchParamsType = {
+        ...searchParams,
+        cursor: cursor?.toString(),
+      };
+
+      const moreProductsData = await fetchMoreProductsDummy(nextParams);
+
+      setProductsData((prevData) => ({
+        ...moreProductsData,
+        content: [...prevData.content, ...moreProductsData.content],
+      }));
+
+      setHasMore(moreProductsData.hasNext);
+
+      if (moreProductsData.nextCursor) {
+        updateUrlWithCursor(moreProductsData.nextCursor);
+      }
+    } catch (error) {
+      console.error('추가 상품 로드 중 오류:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateUrlWithCursor = (newCursor: number) => {
+    const params = new URLSearchParams(searchParamsObj.toString());
+    params.set('cursor', newCursor.toString());
+
+    router.push(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <section className='mt-4 px-4'>
+      <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'>
+        {productsData.content.map((product, index) => {
+          const isLastItem = index === productsData.content.length - 1;
+
+          return (
+            <div key={product.productCode} ref={isLastItem ? lastProductRef : undefined}>
+              <FilteredProductItemCard productCode={product.productCode} />
+            </div>
+          );
+        })}
+      </div>
+
+      {!hasMore && productsData.content.length > 0 && (
+        <div className='text-center my-8 text-gray-500'>모든 상품을 불러왔습니다.</div>
+      )}
+
+      {!loading && productsData.content.length === 0 && (
+        <div className='text-center my-16 p-8 bg-gray-50 rounded-lg'>
+          <p className='text-lg text-gray-500'>조회된 상품이 없습니다.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -1,11 +1,11 @@
 'use client';
-
 import React, { useState, useRef, useCallback } from 'react';
-import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
-import FilteredProductItemCard from '@/components/modules/product/FilteredProductItemCard';
-import { getInitialProductsDummyData } from '@/data/productDummy/filteredProductDummy';
 import { useRouter, useSearchParams } from 'next/navigation';
+
+import { getInitialProductsDummyData } from '@/data/productDummy/filteredProductDummy';
+import FilteredProductItemCard from '@/components/modules/product/FilteredProductItemCard';
 import SortProducts from '@/components/modules/product/SortProducts';
+import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
 
 interface ProductItem {
   id: number;

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
 import FilteredProductItemCard from '@/components/modules/product/FilteredProductItemCard';
-import { getInitialProductsData } from '@/data/productDummy/filteredProductDummy';
+import { getInitialProductsDummyData } from '@/data/productDummy/filteredProductDummy';
 import { useRouter, useSearchParams } from 'next/navigation';
 import SortProducts from '@/components/modules/product/SortProducts';
 
@@ -29,7 +29,7 @@ async function fetchMoreProductsDummy(params: SearchParamsType): Promise<Product
     return new Promise((resolve) => {
       setTimeout(() => {
         const cursor = params.cursor ? Number(params.cursor) : undefined;
-        const moreData = getInitialProductsData(cursor);
+        const moreData = getInitialProductsDummyData(cursor);
         resolve(moreData);
       }, 300); // 로딩 효과를 보여주기 위한 지연
     });
@@ -115,7 +115,7 @@ export default function FilteredProductSection({ searchParams, initialProductsDa
           const isLastItem = index === productsData.content.length - 1;
 
           return (
-            <div key={product.productCode} ref={isLastItem ? lastProductRef : undefined}>
+            <div key={`${product.id}-${index}`} ref={isLastItem ? lastProductRef : undefined}>
               <FilteredProductItemCard productCode={product.productCode} />
             </div>
           );

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -5,6 +5,7 @@ import { SearchParamsType } from '@/data/productDummy/productSearchTypes';
 import FilteredProductItemCard from '@/components/modules/product/FilteredProductItemCard';
 import { getInitialProductsData } from '@/data/productDummy/filteredProductDummy';
 import { useRouter, useSearchParams } from 'next/navigation';
+import SortProducts from '@/components/modules/product/SortProducts';
 
 interface ProductItem {
   id: number;
@@ -106,6 +107,9 @@ export default function FilteredProductSection({ searchParams, initialProductsDa
 
   return (
     <section className='mt-4 px-4'>
+      <div className='flex justify-end mb-4'>
+        <SortProducts />
+      </div>
       <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'>
         {productsData.content.map((product, index) => {
           const isLastItem = index === productsData.content.length - 1;

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -12,7 +12,7 @@ interface ProductItem {
   productCode: number;
 }
 
-interface ProductListData {
+interface ProductListDataType {
   content: ProductItem[];
   hasNext: boolean;
   nextCursor: number | null;
@@ -20,10 +20,10 @@ interface ProductListData {
 
 interface FilteredProductSectionProps {
   searchParams: SearchParamsType;
-  initialProductsData: ProductListData;
+  initialProductsData: ProductListDataType;
 }
 
-async function fetchMoreProductsDummy(params: SearchParamsType): Promise<ProductListData> {
+async function fetchMoreProductsDummy(params: SearchParamsType): Promise<ProductListDataType> {
   try {
     // 지연 효과를 주기 위한 setTimeout 사용
     return new Promise((resolve) => {
@@ -45,7 +45,7 @@ export default function FilteredProductSection({ searchParams, initialProductsDa
 
   const cursor = searchParamsObj.get('cursor') ? Number(searchParamsObj.get('cursor')) : initialProductsData.nextCursor;
 
-  const [productsData, setProductsData] = useState<ProductListData>(initialProductsData);
+  const [productsData, setProductsData] = useState<ProductListDataType>(initialProductsData);
   const [loading, setLoading] = useState(false);
 
   const [hasMore, setHasMore] = useState(initialProductsData.hasNext);

--- a/src/components/layouts/product/FilteredProductSection.tsx
+++ b/src/components/layouts/product/FilteredProductSection.tsx
@@ -51,24 +51,18 @@ export default function FilteredProductSection({ searchParams, initialProductsDa
   const [hasMore, setHasMore] = useState(initialProductsData.hasNext);
 
   const observerRef = useRef<IntersectionObserver | null>(null);
-  const lastProductRef = useCallback(
-    (node: HTMLDivElement) => {
-      if (loading) return;
 
-      if (observerRef.current) observerRef.current.disconnect();
+  const updateUrlWithCursor = useCallback(
+    (newCursor: number) => {
+      const params = new URLSearchParams(searchParamsObj.toString());
+      params.set('cursor', newCursor.toString());
 
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          loadMoreProducts();
-        }
-      });
-
-      if (node) observerRef.current.observe(node);
+      router.push(`?${params.toString()}`, { scroll: false });
     },
-    [loading, hasMore, cursor],
+    [router, searchParamsObj],
   );
 
-  const loadMoreProducts = async () => {
+  const loadMoreProducts = useCallback(async () => {
     if (!hasMore || loading) return;
 
     setLoading(true);
@@ -96,14 +90,24 @@ export default function FilteredProductSection({ searchParams, initialProductsDa
     } finally {
       setLoading(false);
     }
-  };
+  }, [loading, hasMore, cursor, searchParams, updateUrlWithCursor]);
 
-  const updateUrlWithCursor = (newCursor: number) => {
-    const params = new URLSearchParams(searchParamsObj.toString());
-    params.set('cursor', newCursor.toString());
+  const lastProductRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (loading) return;
 
-    router.push(`?${params.toString()}`, { scroll: false });
-  };
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          loadMoreProducts();
+        }
+      });
+
+      if (node) observerRef.current.observe(node);
+    },
+    [loading, hasMore, loadMoreProducts],
+  );
 
   return (
     <section className='mt-4 px-4'>

--- a/src/components/modules/product/FilteredProductItemCard.tsx
+++ b/src/components/modules/product/FilteredProductItemCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 
 import Tag from '../../ui/main/Tag';
 import { getProductDetailDummy, ProductDetail } from '@/actions/product-service';
+import FilteredProductItemCardSkelton from './FilteredProductItemCardSkelton';
 
 interface FilteredProductCardProps {
   productCode: number;
@@ -30,13 +31,7 @@ export default function FilteredProductItemCard({ productCode }: FilteredProduct
   }, [productCode]);
 
   if (loading) {
-    return (
-      <div className='w-full animate-pulse'>
-        <div className='aspect-square w-full bg-gray-200 rounded-[4px]'></div>
-        <div className='h-4 bg-gray-200 rounded my-3 w-3/4'></div>
-        <div className='h-4 bg-gray-200 rounded w-1/2'></div>
-      </div>
-    );
+    return <FilteredProductItemCardSkelton />;
   }
   if (!product) return;
 

--- a/src/components/modules/product/FilteredProductItemCard.tsx
+++ b/src/components/modules/product/FilteredProductItemCard.tsx
@@ -1,9 +1,9 @@
 'use client';
-
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
-import Tag from '../../ui/main/Tag';
 import Link from 'next/link';
+
+import Tag from '../../ui/main/Tag';
 import { getProductDetailDummy, ProductDetail } from '@/actions/product-service';
 
 interface FilteredProductCardProps {

--- a/src/components/modules/product/FilteredProductItemCard.tsx
+++ b/src/components/modules/product/FilteredProductItemCard.tsx
@@ -4,17 +4,7 @@ import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Tag from '../../ui/main/Tag';
 import Link from 'next/link';
-import { dummyProductDetail } from '@/data/productDummy/filteredProductDummy';
-
-interface ProductDetail {
-  productCode: number;
-  productName: string;
-  price: number;
-  productThumbnailUrl: string;
-  isNew?: boolean;
-  isBest?: boolean;
-  isMarkable?: boolean;
-}
+import { getProductDetailDummy, ProductDetail } from '@/actions/product-service';
 
 interface FilteredProductCardProps {
   productCode: number;
@@ -25,10 +15,18 @@ export default function FilteredProductItemCard({ productCode }: FilteredProduct
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setTimeout(() => {
-      setProduct(dummyProductDetail);
-      setLoading(false);
-    }, 300); // 로딩 상태를 보여주기 위한 짧은 지연
+    const fetchProductDetail = async () => {
+      try {
+        const productDetail = await getProductDetailDummy(productCode); //Dummy만 빼면 됨 나중에
+        setProduct(productDetail);
+      } catch (error) {
+        console.error('상품 정보 로딩 실패', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProductDetail();
   }, [productCode]);
 
   if (loading) {
@@ -45,18 +43,18 @@ export default function FilteredProductItemCard({ productCode }: FilteredProduct
   return (
     <Link href={`/products/${product.productCode}`} scroll={false} className='block w-full'>
       <div className='w-full'>
-        <div className='relative aspect-square w-full '>
+        <div className='relative aspect-square w-full mb-2'>
           <Image
-            src='/images/productThumbnails/1000.png'
-            alt='아주멋진 이미지입니다.'
+            src={product.productThumbnailUrl}
+            alt={product.productName}
             className='rounded-[4px]'
             fill
             sizes='100%'
           />
         </div>
-        <Tag isMarkable={true} isNew={false} isBest={true} />
-        <h3 className='text-button2 my-3'>SS 플라워 마켓 스탠리 텀블러 591ml</h3>
-        <p className='text-subtitle2'>7000원</p>
+        <Tag isMarkable={product.isMarkable} isNew={product.isNew} isBest={product.isBest} />
+        <h3 className='text-button2 my-3'>{product.productName}</h3>
+        <p className='text-subtitle2'>{product.price.toLocaleString()}원</p>
       </div>
     </Link>
   );

--- a/src/components/modules/product/FilteredProductItemCard.tsx
+++ b/src/components/modules/product/FilteredProductItemCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Tag from '../../ui/main/Tag';
+import Link from 'next/link';
+import { dummyProductDetail } from '@/data/productDummy/filteredProductDummy';
+
+interface ProductDetail {
+  productCode: number;
+  productName: string;
+  price: number;
+  productThumbnailUrl: string;
+  isNew?: boolean;
+  isBest?: boolean;
+  isMarkable?: boolean;
+}
+
+interface FilteredProductCardProps {
+  productCode: number;
+}
+
+export default function FilteredProductItemCard({ productCode }: FilteredProductCardProps) {
+  const [product, setProduct] = useState<ProductDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setProduct(dummyProductDetail);
+      setLoading(false);
+    }, 300); // 로딩 상태를 보여주기 위한 짧은 지연
+  }, [productCode]);
+
+  if (loading) {
+    return (
+      <div className='w-full animate-pulse'>
+        <div className='aspect-square w-full bg-gray-200 rounded-[4px]'></div>
+        <div className='h-4 bg-gray-200 rounded my-3 w-3/4'></div>
+        <div className='h-4 bg-gray-200 rounded w-1/2'></div>
+      </div>
+    );
+  }
+  if (!product) return;
+
+  return (
+    <Link href={`/products/${product.productCode}`} scroll={false} className='block w-full'>
+      <div className='w-full'>
+        <div className='relative aspect-square w-full'>
+          <Image
+            src='/images/productThumbnails/1000.png'
+            alt='아주멋진 이미지입니다.'
+            className='rounded-[4px]'
+            fill
+            sizes='100%'
+          />
+        </div>
+        <Tag isMarkable={true} isNew={false} isBest={true} />
+        <h3 className='text-button2 my-3'>SS 플라워 마켓 스탠리 텀블러 591ml</h3>
+        <p className='text-subtitle2'>7000원</p>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/modules/product/FilteredProductItemCard.tsx
+++ b/src/components/modules/product/FilteredProductItemCard.tsx
@@ -45,7 +45,7 @@ export default function FilteredProductItemCard({ productCode }: FilteredProduct
   return (
     <Link href={`/products/${product.productCode}`} scroll={false} className='block w-full'>
       <div className='w-full'>
-        <div className='relative aspect-square w-full'>
+        <div className='relative aspect-square w-full '>
           <Image
             src='/images/productThumbnails/1000.png'
             alt='아주멋진 이미지입니다.'

--- a/src/components/modules/product/FilteredProductItemCardSkelton.tsx
+++ b/src/components/modules/product/FilteredProductItemCardSkelton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function FilteredProductItemCardSkelton() {
+  return (
+    <div className='w-full animate-pulse'>
+      <div className='aspect-square w-full bg-gray-200 rounded-[4px]'></div>
+      <div className='h-4 bg-gray-200 rounded my-3 w-3/4'></div>
+      <div className='h-4 bg-gray-200 rounded w-1/2'></div>
+    </div>
+  );
+}

--- a/src/components/modules/product/SortProducts.tsx
+++ b/src/components/modules/product/SortProducts.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 
 import UpIcon from '@/assets/icons/common/up.svg';
+import { cn } from '@/lib/utils';
 
 export default function SortProducts() {
   const router = useRouter();
@@ -67,9 +68,10 @@ export default function SortProducts() {
           {sortOptions.map((option) => (
             <button
               key={option.value}
-              className={`block w-full text-center px-4 py-3 text-sm hover:bg-gray-100  ${
-                currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700'
-              }`}
+              className={cn(
+                'block w-full text-center px-4 py-3 text-sm hover:bg-gray-100',
+                currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700',
+              )}
               onClick={() => handleSortSelect(option.value)}
             >
               {option.label}

--- a/src/components/modules/product/SortProducts.tsx
+++ b/src/components/modules/product/SortProducts.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { useEffect, useRef, useState } from 'react';
+
+import UpIcon from '@/assets/icons/common/up.svg';
+
+export default function SortProducts() {
+  const router = useRouter();
+  const searchParamsObj = useSearchParams();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const sortOptions = [
+    { value: 'createdAt,desc', label: '신상품순' },
+    { value: '', label: '추천순' },
+    { value: 'price,asc', label: '낮은가격순' },
+    { value: 'price,desc', label: '높은가격순' },
+  ];
+
+  // 현재 정렬 값 가져오기
+  const currentSortValue = searchParamsObj.get('sortBy') || '';
+
+  // 현재 정렬 라벨 찾기
+  const currentSortLabel = sortOptions.find((option) => option.value === currentSortValue)?.label || '추천순';
+
+  const handleSortSelect = (sortValue: string) => {
+    const params = new URLSearchParams(searchParamsObj.toString());
+
+    params.delete('cursor');
+
+    if (sortValue) {
+      params.set('sortBy', sortValue);
+    } else {
+      params.delete('sortBy');
+    }
+
+    router.push(`?${params.toString()}`);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className='relative' ref={dropdownRef}>
+      <button
+        className='flex items-center justify-between w-full px-4 py-2 text-sm whitespace-nowrap'
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className='mr-1'>{currentSortLabel}</span>
+        <UpIcon />
+      </button>
+
+      {isOpen && (
+        <div className='absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg truncate whitespace-nowrap'>
+          {sortOptions.map((option) => (
+            <button
+              key={option.value}
+              className={`block w-full text-center px-4 py-3 text-sm hover:bg-gray-100 ${
+                currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700'
+              }`}
+              onClick={() => handleSortSelect(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/modules/product/SortProducts.tsx
+++ b/src/components/modules/product/SortProducts.tsx
@@ -63,11 +63,11 @@ export default function SortProducts() {
       </button>
 
       {isOpen && (
-        <div className='absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg truncate whitespace-nowrap'>
+        <div className='absolute z-10 w-full mt-1 mr-1 bg-white border border-gray-300 rounded-md shadow-lg truncate whitespace-nowrap'>
           {sortOptions.map((option) => (
             <button
               key={option.value}
-              className={`block w-full text-center px-4 py-3 text-sm hover:bg-gray-100 ${
+              className={`block w-full text-center px-4 py-3 text-sm hover:bg-gray-100  ${
                 currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700'
               }`}
               onClick={() => handleSortSelect(option.value)}

--- a/src/components/modules/product/SortProducts.tsx
+++ b/src/components/modules/product/SortProducts.tsx
@@ -64,20 +64,21 @@ export default function SortProducts() {
       </button>
 
       {isOpen && (
-        <div className='absolute z-10 w-full mt-1 mr-1 bg-white border border-gray-300 rounded-md shadow-lg truncate whitespace-nowrap'>
+        <ul className='absolute z-10 w-full mt-1 mr-1 bg-white border border-gray-300 rounded-md shadow-lg truncate whitespace-nowrap'>
           {sortOptions.map((option) => (
-            <button
-              key={option.value}
-              className={cn(
-                'block w-full text-center px-4 py-3 text-sm hover:bg-gray-100',
-                currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700',
-              )}
-              onClick={() => handleSortSelect(option.value)}
-            >
-              {option.label}
-            </button>
+            <li key={option.value}>
+              <button
+                className={cn(
+                  'block w-full text-center px-4 py-3 text-sm hover:bg-gray-100',
+                  currentSortValue === option.value ? 'text-primary-100 font-medium' : 'text-gray-700',
+                )}
+                onClick={() => handleSortSelect(option.value)}
+              >
+                {option.label}
+              </button>
+            </li>
           ))}
-        </div>
+        </ul>
       )}
     </div>
   );

--- a/src/components/ui/main/Tag.tsx
+++ b/src/components/ui/main/Tag.tsx
@@ -10,7 +10,7 @@ interface TagProps {
 
 export default function Tag({ isMarkable, isNew, isBest }: TagProps) {
   return (
-    <div className='flex items-center space-x-1 whitespace-nowrap overflow-hidde mt-2'>
+    <div className='flex items-center space-x-1 whitespace-nowrap overflow-hidden mt-2'>
       {isMarkable && <IconLimited />}
       {isNew && <IconNew />}
       {isBest && <IconBest />}

--- a/src/components/ui/main/Tag.tsx
+++ b/src/components/ui/main/Tag.tsx
@@ -10,10 +10,10 @@ interface TagProps {
 
 export default function Tag({ isMarkable, isNew, isBest }: TagProps) {
   return (
-    <span className='inline'>
+    <div className='flex items-center space-x-1 whitespace-nowrap overflow-hidde mt-2'>
       {isMarkable && <IconLimited />}
       {isNew && <IconNew />}
       {isBest && <IconBest />}
-    </span>
+    </div>
   );
 }

--- a/src/data/productDummy/filteredProductDummy.ts
+++ b/src/data/productDummy/filteredProductDummy.ts
@@ -1,0 +1,104 @@
+export interface ProductItem {
+  id: number;
+  productCode: number;
+}
+
+export interface ProductDetail {
+  productCode: number;
+  productName: string;
+  price: number;
+  productThumbnailUrl: string;
+  isNew?: boolean;
+  isBest?: boolean;
+  isMarkable?: boolean;
+}
+
+export const productItemList: ProductItem[] = [
+  { id: 1, productCode: 1000 },
+  { id: 2, productCode: 1001 },
+  { id: 3, productCode: 1002 },
+  { id: 4, productCode: 1003 },
+  { id: 5, productCode: 1004 },
+  { id: 6, productCode: 1005 },
+  { id: 7, productCode: 1006 },
+  { id: 8, productCode: 1007 },
+  { id: 9, productCode: 1008 },
+  { id: 10, productCode: 1009 },
+  { id: 11, productCode: 1010 },
+  { id: 12, productCode: 1011 },
+  { id: 13, productCode: 1012 },
+  { id: 14, productCode: 1013 },
+  { id: 15, productCode: 1014 },
+  { id: 16, productCode: 1015 },
+  { id: 17, productCode: 1016 },
+  { id: 18, productCode: 1017 },
+  { id: 19, productCode: 1018 },
+  { id: 20, productCode: 1019 },
+  { id: 21, productCode: 1020 },
+  { id: 22, productCode: 1021 },
+  { id: 23, productCode: 1022 },
+  { id: 24, productCode: 1023 },
+  { id: 25, productCode: 1024 },
+  { id: 26, productCode: 1025 },
+  { id: 27, productCode: 1026 },
+  { id: 28, productCode: 1027 },
+  { id: 29, productCode: 1028 },
+  { id: 30, productCode: 1029 },
+  { id: 31, productCode: 1030 },
+  { id: 32, productCode: 1031 },
+  { id: 33, productCode: 1032 },
+  { id: 34, productCode: 1033 },
+  { id: 35, productCode: 1034 },
+  { id: 36, productCode: 1035 },
+  { id: 37, productCode: 1036 },
+  { id: 38, productCode: 1037 },
+  { id: 39, productCode: 1038 },
+  { id: 40, productCode: 1039 },
+  { id: 41, productCode: 1040 },
+  { id: 42, productCode: 1041 },
+  { id: 43, productCode: 1042 },
+  { id: 44, productCode: 1043 },
+  { id: 45, productCode: 1044 },
+  { id: 46, productCode: 1045 },
+  { id: 47, productCode: 1046 },
+  { id: 48, productCode: 1047 },
+  { id: 49, productCode: 1048 },
+  { id: 50, productCode: 1049 },
+];
+
+// 고정된 더미 상품 상세 정보
+export const dummyProductDetail: ProductDetail = {
+  productCode: 1000,
+  productName: 'SS 플라워 마켓 스탠리 텀블러 591ml',
+  price: 7000,
+  productThumbnailUrl: '/images/productThumbnails/1000.png',
+  isNew: true,
+  isBest: true,
+  isMarkable: true,
+};
+
+// 상품 상세 정보를 가져오는 더미 함수
+export async function getProductDetail(productCode: number): Promise<ProductDetail> {
+  // 항상 같은 더미 데이터 반환
+  console.log(productCode);
+
+  return dummyProductDetail;
+}
+
+// 초기 상품 데이터 로딩 함수
+export function getInitialProductsData(cursor?: number): {
+  content: ProductItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+} {
+  const pageSize = 10;
+  const startIndex = cursor ? productItemList.findIndex((p) => p.productCode === cursor) + 1 : 0;
+
+  const content = productItemList.slice(startIndex, startIndex + pageSize);
+
+  return {
+    content,
+    hasNext: startIndex + pageSize < productItemList.length,
+    nextCursor: content.length > 0 ? content[content.length - 1].productCode : null,
+  };
+}

--- a/src/data/productDummy/filteredProductDummy.ts
+++ b/src/data/productDummy/filteredProductDummy.ts
@@ -8,9 +8,7 @@ export interface ProductDetail {
   productName: string;
   price: number;
   productThumbnailUrl: string;
-  isNew?: boolean;
-  isBest?: boolean;
-  isMarkable?: boolean;
+  markable?: boolean;
 }
 
 export const productItemList: ProductItem[] = [
@@ -72,9 +70,7 @@ export const dummyProductDetail: ProductDetail = {
   productName: 'SS 플라워 마켓 스탠리 텀블러 591ml',
   price: 7000,
   productThumbnailUrl: '/images/productThumbnails/1000.png',
-  isNew: true,
-  isBest: true,
-  isMarkable: true,
+  markable: true,
 };
 
 // 상품 상세 정보를 가져오는 더미 함수
@@ -86,7 +82,7 @@ export async function getProductDetail(productCode: number): Promise<ProductDeta
 }
 
 // 초기 상품 데이터 로딩 함수
-export function getInitialProductsData(cursor?: number): {
+export function getInitialProductsDummyData(cursor?: number): {
   content: ProductItem[];
   hasNext: boolean;
   nextCursor: number | null;

--- a/src/types/products/productTypes.ts
+++ b/src/types/products/productTypes.ts
@@ -7,3 +7,18 @@ export interface ProductTypes {
   markable: string;
   price: number;
 }
+
+export interface ProductItem {
+  id: number;
+  productCode: number;
+}
+
+export interface ProductListData {
+  content: ProductItem[];
+  hasNext: boolean;
+  nextCursor: string | null;
+}
+
+export interface ProductsWithDetailsData extends ProductListData {
+  productDetails: ProductTypes[];
+}

--- a/src/types/products/productTypes.ts
+++ b/src/types/products/productTypes.ts
@@ -13,12 +13,12 @@ export interface ProductItem {
   productCode: number;
 }
 
-export interface ProductListData {
+export interface ProductListDataType {
   content: ProductItem[];
   hasNext: boolean;
   nextCursor: string | null;
 }
 
-export interface ProductsWithDetailsData extends ProductListData {
+export interface ProductsWithDetailsDataType extends ProductListDataType {
   productDetails: ProductTypes[];
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #52 

## 📝작업 내용

> 상품 조회 페이지 , 상품 리스트 섹션 퍼블리싱

정렬 컴포넌트 생성 및 적용

무한스크롤 적용(cusor값 이용)
- 현재는 이전 커서가 없어서, 새로고침하게 되면 전의 데이터가 다 날라간다.
- 이전커서가 있다면 해결 가능


### 스크린샷 (선택)

<정렬 컴포넌트>
![IMG_8582](https://github.com/user-attachments/assets/35c729ed-065b-436f-a248-d23557ebf074)

<무한스크롤>
![IMG_8583](https://github.com/user-attachments/assets/4f4cc54b-0692-4bfa-be1a-fd179d102f3f)





## 💬리뷰 요구사항(선택)

> 코드 엉망일것입니다.
마구마구 지적 9다SAI
